### PR TITLE
Update links and text to refer to https://rustrpm.org

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 categories  = ["api-bindings", "os", "parsing"]
 keywords    = ["rpm", "linux", "redhat", "fedora", "centos"]
 readme      = "README.md"
-homepage    = "https://rpmlib.rs/librpm/"
+homepage    = "https://rustrpm.org/librpm/"
 
 [dependencies]
 failure = "0.1"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The [librpm] C library (available in the `rpm-devel` RPM package) exposes a
 programmatic interface to the [RPM Package Manager], and this crate aims to
 provide a safe, idiomatic Rust wrapper.
 
-[Documentation](https://librpm.rs/librpm/)
+[Documentation](https://rustrpm.org/librpm/)
 
 [librpm]: http://ftp.rpm.org/api/4.14.0/
 [RPM Package Manager]: http://rpm.org/

--- a/librpm-sys/Cargo.toml
+++ b/librpm-sys/Cargo.toml
@@ -7,7 +7,7 @@ authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 categories  = ["external-ffi-bindings", "os"]
 keywords    = ["rpm", "linux", "redhat", "fedora", "centos"]
 readme      = "README.md"
-homepage    = "https://librpm.rs/librpm-sys/"
+homepage    = "https://rustrpm.org/librpm-sys/"
 repository  = "https://github.com/rustrpm/librpm-rs/tree/master/librpm-sys"
 
 [badges]

--- a/librpm-sys/README.md
+++ b/librpm-sys/README.md
@@ -19,12 +19,12 @@ This crate isn't intended to be used directly, but instead provides an unsafe,
 low-level binding used by the higher level **librpm** crate, which aims to
 provide a safe, idiomatic, high-level binding to the C library:
 
-https://librpm.rs/
+https://rustrpm.org/
 
 If you're intending to add a feature to the **librpm** crate however, you have
 come to the right place. You can find documentation here:
 
-[Documentation]: https://librpm.rs/librpm-sys/
+[Documentation]: https://rustrpm.org/librpm-sys/
 
 [librpm C library]: http://ftp.rpm.org/api/4.14.0/
 [RPM Package Manager]: http://rpm.org/

--- a/librpm-sys/include/librpm.hpp
+++ b/librpm-sys/include/librpm.hpp
@@ -1,4 +1,4 @@
-// rpmlib.hpp: Wrapper for rpmlib header files to be passed to bindgen
+// librpm.hpp: Wrapper for librpm header files to be passed to bindgen
 //
 // See "Using the RPM Library" section of "Chapter 15. Programming RPM with C"
 // of the Fedora RPM Guide (Draft 0.1):
@@ -11,11 +11,11 @@
 // ## Why does this file have a `.hpp` extension (i.e. why a C++ binding?)
 //
 // This file has a `.hpp` extension to signal to bindgen to treat it (and
-// the rest of the rpmlib header files) as C++. Though that may seem a little
+// the rest of the librpm header files) as C++. Though that may seem a little
 // crazy, there's actually a good reason for it.
 //
 // Some of RPM's header files (namely `/usr/include/popt.h`, which is included
-// by several important rpmlib headers including `rpmbuild.h`, `rpmsign.h`, and
+// by several important librpm headers including `rpmbuild.h`, `rpmsign.h`, and
 // `rpmspec.h) define pointer typedefs for structs with the same name as the
 // structs they point to, which is valid in C but not valid in C++, and
 // likewise also not valid in bindgen's generated bindings for the same reason:
@@ -25,10 +25,10 @@
 //
 // By naming this file with a .hpp extension we instruct bindgen to produce a
 // C++ binding instead of a C one, which triggers macro-based gating (i.e.
-// `#ifdef __cplusplus`) througout rpmlib's headers.
+// `#ifdef __cplusplus`) throughout librpm's headers.
 //
 // Treating the headers as C++ prevents them from defining these sorts of type
-// aliases and allows us to bind to more of rpmlib than we can using C.
+// aliases and allows us to bind to more of librpm than we can using C.
 //
 // Additionally it resolved bindgen-generated test failures for memory
 // alignment, allowing us to generate a low-level binding for all parts of

--- a/librpm-sys/src/lib.rs
+++ b/librpm-sys/src/lib.rs
@@ -8,7 +8,7 @@
 #![crate_type = "rlib"]
 #![allow(unknown_lints, clippy)]
 #![allow(non_upper_case_globals, non_camel_case_types, non_snake_case)]
-#![doc(html_root_url = "https://librpm.rs/librpm-sys/")]
+#![doc(html_root_url = "https://rustrpm.org/librpm_sys/")]
 
 /// Bindings to librpm.so and librpmio.so
 include!(concat!(env!("OUT_DIR"), "/binding.rs"));

--- a/librpmbuild-sys/Cargo.toml
+++ b/librpmbuild-sys/Cargo.toml
@@ -7,7 +7,7 @@ authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 categories  = ["external-ffi-bindings", "os"]
 keywords    = ["rpm", "linux", "redhat", "fedora", "centos"]
 readme      = "README.md"
-homepage    = "https://librpm.rs/librpm-sys/"
+homepage    = "https://rustrpm.org/librpm-sys/"
 repository  = "https://github.com/rustrpm/librpm-rs/tree/master/librpmbuild-sys"
 
 [badges]

--- a/librpmbuild-sys/README.md
+++ b/librpmbuild-sys/README.md
@@ -19,7 +19,7 @@ This crate isn't intended to be used directly, but instead provides an unsafe,
 low-level binding used by the higher level **librpm** crate, which aims to
 provide a safe, idiomatic, high-level binding to the C library:
 
-https://librpm.rs/
+https://rustrpm.org/
 
 [rpmbuild C library]: http://ftp.rpm.org/api/4.14.0/group__rpmbuild.html
 [RPM Package Manager]: http://rpm.org/

--- a/librpmbuild-sys/include/librpmbuild.hpp
+++ b/librpmbuild-sys/include/librpmbuild.hpp
@@ -1,4 +1,4 @@
-// rpmbuild.hpp: Wrapper for rpmlib header files to be passed to bindgen
+// rpmbuild.hpp: Wrapper for librpmbuild header files to be passed to bindgen
 
 /** librpmbuild headers */
 #include <rpm/rpmbuild.h>

--- a/librpmbuild-sys/src/lib.rs
+++ b/librpmbuild-sys/src/lib.rs
@@ -9,7 +9,7 @@
 #![crate_type = "rlib"]
 #![allow(unknown_lints, clippy)]
 #![allow(non_upper_case_globals, non_camel_case_types, non_snake_case)]
-#![doc(html_root_url = "https://librpm.rs/librpmbuild-sys/")]
+#![doc(html_root_url = "https://rustrpm.org/librpmbuild_sys/")]
 
 /// Bindings to librpmbuild.so
 include!(concat!(env!("OUT_DIR"), "/binding.rs"));

--- a/librpmsign-sys/Cargo.toml
+++ b/librpmsign-sys/Cargo.toml
@@ -7,7 +7,7 @@ authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 categories  = ["external-ffi-bindings", "os"]
 keywords    = ["rpm", "linux", "redhat", "fedora", "centos"]
 readme      = "README.md"
-homepage    = "https://librpm.rs/librpmsign-sys/"
+homepage    = "https://rustrpm.org/librpmsign-sys/"
 repository  = "https://github.com/rustrpm/librpm-rs/tree/master/librpmsign-sys"
 
 [badges]

--- a/librpmsign-sys/README.md
+++ b/librpmsign-sys/README.md
@@ -19,7 +19,7 @@ This crate isn't intended to be used directly, but instead provides an unsafe,
 low-level binding used by the higher level **librpm** crate, which aims to
 provide a safe, idiomatic, high-level binding to the C library:
 
-https://librpm.rs/
+https://rustrpm.org/
 
 [rpmsign C library]: http://ftp.rpm.org/api/4.14.0/group__rpmsign.html
 

--- a/librpmsign-sys/include/librpmsign.hpp
+++ b/librpmsign-sys/include/librpmsign.hpp
@@ -1,4 +1,4 @@
-// rpmsign.hpp: Wrapper for rpmlib header files to be passed to bindgen
+// rpmsign.hpp: Wrapper for librpmsign header files to be passed to bindgen
 
 /** librpmsign headers */
 #include <rpm/rpmsign.h>

--- a/librpmsign-sys/src/lib.rs
+++ b/librpmsign-sys/src/lib.rs
@@ -9,7 +9,7 @@
 #![crate_type = "rlib"]
 #![allow(unknown_lints, clippy)]
 #![allow(non_upper_case_globals, non_camel_case_types, non_snake_case)]
-#![doc(html_root_url = "https://librpm.rs/librpmsign-sys/")]
+#![doc(html_root_url = "https://rustrpm.org/librpmsign_sys/")]
 
 /// Bindings to librpmsign.so
 include!(concat!(env!("OUT_DIR"), "/binding.rs"));

--- a/src/internal/ts.rs
+++ b/src/internal/ts.rs
@@ -6,7 +6,7 @@ use std::sync::MutexGuard;
 
 use internal::GlobalState;
 
-/// librpm transactions, a.k.a. "transaction sets" (or "rpmts" in rpmlib)
+/// librpm transactions, a.k.a. "transaction sets" (or `rpmts` librpm type)
 ///
 /// Nearly all access to librpm, including actions which don't necessarily
 /// involve operations on the RPM database, require a transaction set.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,13 +9,13 @@
 //! See the `librpm::db::Database` type for examples of how to interact with
 //! the RPM database.
 //!
-//! [librpm-sys]: https://rpmlib.rs/rpmlib-sys/
+//! [librpm-sys]: https://rustrpm.org/librpm_sys/index.html
 
 #![crate_name = "librpm"]
 #![crate_type = "rlib"]
 #![deny(warnings, missing_docs, trivial_casts, trivial_numeric_casts)]
 #![deny(unused_import_braces, unused_qualifications)]
-#![doc(html_root_url = "https://librpm.rs/rpmlib/")]
+#![doc(html_root_url = "https://rustrpm.org/librpm/")]
 
 extern crate failure;
 #[macro_use]


### PR DESCRIPTION
Fixes any old references to rpmlib.rs, librpm.rs, or the old name "rpmlib" in general